### PR TITLE
Replace `draft` with `environment` enum for content visibility

### DIFF
--- a/scripts/generate-graph-data.js
+++ b/scripts/generate-graph-data.js
@@ -371,8 +371,9 @@ function parseMarkdownFile(content, slug) {
           // Single value
           if (key === "date") {
             data[key] = new Date(value);
-          } else if (key === "draft") {
-            data[key] = value === "true";
+          } else if (key === "environment") {
+            // Keep environment as string
+            data[key] = value;
           } else if (
             key === "imageOG" ||
             key === "hideCoverImage" ||
@@ -424,9 +425,17 @@ async function generateGraphData() {
     const posts = readContentFiles(postsDir);
     log.info(`📄 Found ${posts.length} posts`);
 
-    // Filter out draft posts in production
+    // Filter out non-visible posts (Obsidian environment posts never show, Local/Production show in dev, only Production in prod)
     const isDev = process.env.NODE_ENV !== "production" && !process.argv.includes("--production");
-    const visiblePosts = posts.filter((post) => isDev || !post.data.draft);
+    const visiblePosts = posts.filter((post) => {
+      if (post.data.environment === 'Obsidian') {
+        return false; // Never show Obsidian posts
+      }
+      if (isDev) {
+        return post.data.environment === 'Local' || post.data.environment === 'Production';
+      }
+      return post.data.environment === 'Production';
+    });
 
     log.info(`📄 Processing ${visiblePosts.length} visible posts`);
 

--- a/src/components/EnvironmentBanner.astro
+++ b/src/components/EnvironmentBanner.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * EnvironmentBanner Component
+ * Shows a warning banner when content is set to 'Local' environment in dev mode
+ * Only visible in development and when environment === 'Local'
+ */
+
+interface Props {
+  environment?: string;
+}
+
+const { environment } = Astro.props;
+
+// Only show in development mode and when environment is 'Local'
+const isDev = import.meta.env.DEV;
+const showBanner = isDev && environment === 'Local';
+---
+
+{
+  showBanner && (
+    <div class="mb-6 rounded-lg border-l-4 border-highlight-500 bg-highlight-50 p-4 dark:border-highlight-400 dark:bg-highlight-900/20">
+      <div class="flex flex-col gap-2">
+        <strong class="text-highlight-700 dark:text-highlight-300">Warning: Local Preview Only</strong>
+        <p class="m-0 text-sm text-primary-700 dark:text-primary-300">
+          This post will show locally only and will not be
+          published to the live site. To publish it, set the environment to
+          'Production'.
+        </p>
+        <p class="m-0 text-xs text-primary-700 dark:text-primary-300">Don't worry, this banner won't show in production.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -423,7 +423,7 @@ export const siteConfig: SiteConfig = {
     // [CONFIG:POST_OPTIONS_POST_NAVIGATION]
     postNavigation: true,
     // [CONFIG:POST_OPTIONS_SHOW_POST_CARD_COVER_IMAGES]
-    showPostCardCoverImages: "featured-and-posts", // "all" | "featured" | "home" | "posts" | "featured-and-posts" | "none"
+    showPostCardCoverImages: "all", // "all" | "featured" | "home" | "posts" | "featured-and-posts" | "none"
     // [CONFIG:POST_OPTIONS_POST_CARD_ASPECT_RATIO]
     postCardAspectRatio: "og", // "16:9" | "4:3" | "3:2" | "og" | "square" | "golden" | "custom"
     // [CONFIG:POST_OPTIONS_CUSTOM_POST_CARD_ASPECT_RATIO]

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,7 +9,7 @@ const postsCollection = defineCollection({
     description: z.string().nullable().optional().default('No description provided'),
     date: z.coerce.date().default(() => new Date()),
     tags: z.array(z.string()).nullable().optional(),
-    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Obsidian'),
     image: z.any().nullable().optional().transform((val) => {
       // Handle various Obsidian syntax formats
       if (Array.isArray(val)) {
@@ -39,7 +39,7 @@ const pagesCollection = defineCollection({
   schema: z.object({
     title: z.string().default('Untitled Page'),
     description: z.string().nullable().optional().default('No description provided'),
-    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Obsidian'),
     lastModified: z.coerce.date().optional(),
     image: z.any().nullable().optional().transform((val) => {
       // Handle various Obsidian syntax formats
@@ -90,7 +90,7 @@ const projectsCollection = defineCollection({
     hideCoverImage: z.boolean().optional(),
     hideTOC: z.boolean().optional(),
     showTOC: z.boolean().optional(),
-    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Obsidian'),
     noIndex: z.boolean().optional(),
     featured: z.boolean().optional(),
   }),
@@ -121,7 +121,7 @@ const docsCollection = defineCollection({
     imageAlt: z.string().nullable().optional(),
     hideCoverImage: z.boolean().optional(),
     hideTOC: z.boolean().optional(),
-    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Obsidian'),
     noIndex: z.boolean().optional(),
     showTOC: z.boolean().optional(),
     featured: z.boolean().optional(),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,7 +9,7 @@ const postsCollection = defineCollection({
     description: z.string().nullable().optional().default('No description provided'),
     date: z.coerce.date().default(() => new Date()),
     tags: z.array(z.string()).nullable().optional(),
-    draft: z.boolean().optional(),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
     image: z.any().nullable().optional().transform((val) => {
       // Handle various Obsidian syntax formats
       if (Array.isArray(val)) {
@@ -39,7 +39,7 @@ const pagesCollection = defineCollection({
   schema: z.object({
     title: z.string().default('Untitled Page'),
     description: z.string().nullable().optional().default('No description provided'),
-    draft: z.boolean().optional(),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
     lastModified: z.coerce.date().optional(),
     image: z.any().nullable().optional().transform((val) => {
       // Handle various Obsidian syntax formats
@@ -90,7 +90,7 @@ const projectsCollection = defineCollection({
     hideCoverImage: z.boolean().optional(),
     hideTOC: z.boolean().optional(),
     showTOC: z.boolean().optional(),
-    draft: z.boolean().optional(),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
     noIndex: z.boolean().optional(),
     featured: z.boolean().optional(),
   }),
@@ -121,7 +121,7 @@ const docsCollection = defineCollection({
     imageAlt: z.string().nullable().optional(),
     hideCoverImage: z.boolean().optional(),
     hideTOC: z.boolean().optional(),
-    draft: z.boolean().optional(),
+    environment: z.enum(['Obsidian', 'Local', 'Production']).default('Production'),
     noIndex: z.boolean().optional(),
     showTOC: z.boolean().optional(),
     featured: z.boolean().optional(),

--- a/src/content/docs/Book Level 2/chapter-2 1.md
+++ b/src/content/docs/Book Level 2/chapter-2 1.md
@@ -9,13 +9,13 @@ image:
 imageAlt: ""
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Local
 featured: true
 aliases:
 ---
 ## Heading
 
-Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn 
+Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn
 ## another heading
 
-Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn 
+Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn

--- a/src/content/docs/Book level/chapter-1.md
+++ b/src/content/docs/Book level/chapter-1.md
@@ -9,7 +9,7 @@ image: "[[../../attachments/Tactic Fight Final.jpg]]"
 imageAlt:
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Local
 featured: true
 aliases:
 date: 2026-05-18
@@ -17,7 +17,7 @@ date: 2026-05-18
 
 ## Heading
 
-Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn 
+Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn
 ## another heading
 
-Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn 
+Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn Loerm iprsiumm alsoiufgn

--- a/src/content/docs/Book level/chapter-2.md
+++ b/src/content/docs/Book level/chapter-2.md
@@ -9,7 +9,7 @@ image: ""
 imageAlt: ""
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 featured: true
 aliases:
 ---

--- a/src/content/docs/api.md
+++ b/src/content/docs/api.md
@@ -4,15 +4,15 @@ description: Complete API reference for the Astro Modular theme
 category: Astro Modular
 order: 2
 version: 0.8.1
-lastModified: 2026-02-22
+lastModified: 2026-05-18
 image:
 imageAlt:
 hideCoverImage: false
 hideTOC: false
 environment: Obsidian
-featured: false
+featured: true
 aliases:
-  - api-reference
+date: 2026-05-18
 ---
 This document provides a complete reference for the Astro Modular theme APIs, utilities, and configuration options.
 

--- a/src/content/hide/astro-composer.md
+++ b/src/content/hide/astro-composer.md
@@ -13,7 +13,7 @@ image: "[[../projects/attachments/rock.png]]"
 imageAlt: Gray, rocky wall
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 featured: false
 aliases:
   - obsidian-astro-composer

--- a/src/content/hide/configuration.md
+++ b/src/content/hide/configuration.md
@@ -9,7 +9,7 @@ image: "[[attachments/astro-modular-configuration.png]]"
 imageAlt: Astro Modular preview, showing different theme and layout options.
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 featured: false
 aliases:
   - astro-modular-configuration
@@ -302,7 +302,7 @@ description: "A brief description"
 tags: ["tag1", "tag2"]
 image: "cover.jpg"
 imageAlt: "Cover image description"
-draft: false
+environment: Production
 ---
 
 ## Start with H2

--- a/src/content/hide/installing-obsidian.md
+++ b/src/content/hide/installing-obsidian.md
@@ -9,7 +9,7 @@ image: "[[attachments/obsidian-cover.png]]"
 imageAlt: Obsidian logo with a black background.
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 featured: false
 ---
 This guide shows you how to install Obsidian for use with your Astro Modular blog.

--- a/src/content/hide/sourcetree-and-git-setup/index.md
+++ b/src/content/hide/sourcetree-and-git-setup/index.md
@@ -9,7 +9,7 @@ image: "[[sourcetree.png]]"
 imageAlt: SourceTree logo with a blue background.
 hideCoverImage: false
 hideTOC: true
-draft: true
+environment: Obsidian
 featured: false
 aliases:
   - sourcetree-and-git

--- a/src/content/hide/vault-cms/index.md
+++ b/src/content/hide/vault-cms/index.md
@@ -14,7 +14,7 @@ image: "[[glacier.png]]"
 imageAlt: Blue glaciers and mountains.
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 featured: false
 aliases:
   - obsidian-astro-suite

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -3,7 +3,7 @@ title: About
 description: Learn more about Mordite Press. Tabletop role-playing games and misadventures. Seattle - Boston - Argentina - Ireland.
 noIndex: false
 hideTOC: false
-draft: false
+environment: Production
 ---
 **Mordite Press** makes stuff for tabletop RPGs.
 

--- a/src/content/pages/contact.md
+++ b/src/content/pages/contact.md
@@ -3,56 +3,56 @@ title: Contact
 description: Contact me.
 noIndex: false
 hideTOC: false
-draft: false
+environment: Production
 aliases:
   - contact-me
   - contact-us
 ---
-Send me a message. 
+Send me a message.
 
-<form   
-  name="contact"   
-  method="POST"   
-  data-netlify="true"   
+<form
+  name="contact"
+  method="POST"
+  data-netlify="true"
   netlify-honeypot="bot-field"
-  action="/thank-you"  
-  class="form-sleek"  
->  
-  <!-- Hidden honeypot field for spam protection -->  
-  <input type="hidden" name="bot-field" />  
-    
-  <!-- Hidden form name field (required for Netlify) -->  
-  <input type="hidden" name="form-name" value="contact" />  
-    
-  <input   
-    type="text"   
-    id="name"   
-    name="name"   
-    required   
-    class="w-full"   
-    placeholder="Name"  
-  />  
-    
-  <input   
-    type="email"   
-    id="email"   
-    name="email"   
-    required   
-    class="w-full"   
-    placeholder="Email"  
-  />  
-    
-  <textarea   
-    id="message"   
-    name="message"   
-    rows="4"   
-    required   
-    class="w-full"   
-    placeholder="Message"  
-  ></textarea>  
-    
-  <button type="submit" class="btn btn-primary w-full">  
-    Send Message  
-  </button>  
+  action="/thank-you"
+  class="form-sleek"
+>
+  <!-- Hidden honeypot field for spam protection -->
+  <input type="hidden" name="bot-field" />
+
+  <!-- Hidden form name field (required for Netlify) -->
+  <input type="hidden" name="form-name" value="contact" />
+
+  <input
+    type="text"
+    id="name"
+    name="name"
+    required
+    class="w-full"
+    placeholder="Name"
+  />
+
+  <input
+    type="email"
+    id="email"
+    name="email"
+    required
+    class="w-full"
+    placeholder="Email"
+  />
+
+  <textarea
+    id="message"
+    name="message"
+    rows="4"
+    required
+    class="w-full"
+    placeholder="Message"
+  ></textarea>
+
+  <button type="submit" class="btn btn-primary w-full">
+    Send Message
+  </button>
 </form>
 

--- a/src/content/pages/privacy-policy.md
+++ b/src/content/pages/privacy-policy.md
@@ -3,7 +3,7 @@ title: Privacy Policy
 description: This privacy policy explains how your information is collected, used, and protected when you visit this website.
 noIndex: true
 hideTOC: false
-draft: false
+environment: Production
 aliases:
   - privacy
 ---

--- a/src/content/pages/thank-you.md
+++ b/src/content/pages/thank-you.md
@@ -3,6 +3,6 @@ title: Thank You
 description: Thank you for your submission.
 hideTOC: false
 noIndex: false
-draft: true
+environment: Obsidian
 ---
 Your submission has been sent. Expect a response soon!

--- a/src/content/posts/bacon-wrapped-setting/index.md
+++ b/src/content/posts/bacon-wrapped-setting/index.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/circular-tactics.md
+++ b/src/content/posts/circular-tactics.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/doppelgangers.md
+++ b/src/content/posts/doppelgangers.md
@@ -8,7 +8,7 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 aliases:
 ---

--- a/src/content/posts/duamn-on-born-to-lose/index.md
+++ b/src/content/posts/duamn-on-born-to-lose/index.md
@@ -10,7 +10,7 @@ imageAlt: Born to Lose Podcast Logo
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: false
+environment: Production
 noIndex: false
 ---
 The *Born to Lose* podcast sat down to interview game designer and avowed mordite Duamn Figueroa Rassol!

--- a/src/content/posts/encumbrance-brinksmanship.md
+++ b/src/content/posts/encumbrance-brinksmanship.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/forced-retreat-and-open-tables.md
+++ b/src/content/posts/forced-retreat-and-open-tables.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/formatting-reference.md
+++ b/src/content/posts/formatting-reference.md
@@ -15,7 +15,7 @@ imageOG: false
 hideCoverImage: false
 hideTOC: false
 targetKeyword:
-draft: true
+environment: Obsidian
 ---
 This post demonstrates all the markdown, extended markdown, and other embed features available in Astro Modular. Use this as both a reference guide and a showcase of what's possible.
 

--- a/src/content/posts/getting-started.md
+++ b/src/content/posts/getting-started.md
@@ -13,7 +13,7 @@ imageAlt: Sunset skyline.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 ---
 Welcome to Astro Modular! This quick start guide will get your blog running in minutes. Choose your preferred workflow [below](posts/getting-started.md#Choose%20Your%20Workflow).
 

--- a/src/content/posts/group-rolls.md
+++ b/src/content/posts/group-rolls.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/it-cant-be/index.md
+++ b/src/content/posts/it-cant-be/index.md
@@ -9,7 +9,7 @@ image: ./woe_is_you.jpg
 imageAlt: Quint staggers down a corridor, pursued by a megaplasm
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 aliases:
 ---

--- a/src/content/posts/kickless.md
+++ b/src/content/posts/kickless.md
@@ -8,7 +8,7 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---
 The problem with Kickstarter. One problem anyway.

--- a/src/content/posts/list-of-mail.md
+++ b/src/content/posts/list-of-mail.md
@@ -9,7 +9,7 @@ image: "[[https://cdn2.hubspot.net/hubfs/2068068/Mordite%20Mail.png]]"
 imageAlt: "Image for List of Mail"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 ---
 Loyal followers, we have more projects in the works than ever! If you want to stay on top of the latest Mordite Monday posts, crowd-funding announcements and product releases, you should submit to our mailing list.

--- a/src/content/posts/looters-a-game-of-unlicensed-adventure/index.md
+++ b/src/content/posts/looters-a-game-of-unlicensed-adventure/index.md
@@ -9,5 +9,5 @@ imageOG: false
 hideCoverImage: false
 hideTOC: false
 targetKeyword: ""
-draft: true
+environment: Obsidian
 ---

--- a/src/content/posts/obsidian-embeds-demo.md
+++ b/src/content/posts/obsidian-embeds-demo.md
@@ -12,7 +12,7 @@ imageOG: false
 hideCoverImage: false
 hideTOC: false
 targetKeyword: obsidian embeds
-draft: true
+environment: Obsidian
 aliases:
   - mermaid-test
   - mermaid-diagram-test

--- a/src/content/posts/open-licenses.md
+++ b/src/content/posts/open-licenses.md
@@ -8,7 +8,7 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---
 ## The Open License was a Trap

--- a/src/content/posts/planescape-and-rpg-critique.md
+++ b/src/content/posts/planescape-and-rpg-critique.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/playground-treasure.md
+++ b/src/content/posts/playground-treasure.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/rules-for-humans/rules-for-humans.md
+++ b/src/content/posts/rules-for-humans/rules-for-humans.md
@@ -8,7 +8,7 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---
 Way back at the end of 2023, Michael Prescott said [some things](https://blog.trilemma.com/2023/12/whose-mechanic-is-it-anyway.html) about mechanic ownership on his Trilemma Blog and they split my skull open like a woodaxe.

--- a/src/content/posts/stochastic-duration-and-resource-crunch.md
+++ b/src/content/posts/stochastic-duration-and-resource-crunch.md
@@ -8,7 +8,7 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---
 The Grind

--- a/src/content/posts/stupid-fantasy.md
+++ b/src/content/posts/stupid-fantasy.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/posts/torchbearers-edition-war/index.md
+++ b/src/content/posts/torchbearers-edition-war/index.md
@@ -10,7 +10,7 @@ imageOG: false
 hideCoverImage: false
 hideTOC: false
 targetKeyword:
-draft: true
+environment: Obsidian
 ---
 Please forgive the provocative title, a blogger's gotta blog.
 

--- a/src/content/posts/yes-no-and-but.md
+++ b/src/content/posts/yes-no-and-but.md
@@ -8,6 +8,6 @@ imageAlt: Mountains and water.
 imageOG: true
 hideCoverImage: false
 hideTOC: false
-draft: true
+environment: Obsidian
 noIndex: true
 ---

--- a/src/content/projects/fearless-and-freebooting.md
+++ b/src/content/projects/fearless-and-freebooting.md
@@ -9,7 +9,7 @@ image: "[[https://cdn2.hubspot.net/hubfs/2068068/Fear-and-Free-cover_300.jpg]]"
 imageAlt: "Fearless and Freebooting cover"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 ---
 Nine indispensable character classes for bravely plundering, raiding, and looting.

--- a/src/content/projects/roost-of-the-condor-queen.md
+++ b/src/content/projects/roost-of-the-condor-queen.md
@@ -9,7 +9,7 @@ image: "[[https://cdn2.hubspot.net/hubfs/2068068/roost-of-the-condor-queen-torch
 imageAlt: "Roost of the Condor Queen Torchbearer"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: true
 ---
 A century ago, emissaries from Puku would travel into the kingdom of Feudor, offering priceless artifacts to trade and dispensing unique insights into the profound mysteries of the Otherworld. For a hundred years they have languished in myth. Recently a lost traveler turned up with a wild tale of having found the lost city… and a map.

--- a/src/content/projects/the-delvers-guide-to-surviving-the-underworld.md
+++ b/src/content/projects/the-delvers-guide-to-surviving-the-underworld.md
@@ -10,7 +10,7 @@ image: "[[https://f.hubspotusercontent10.net/hubfs/2068068/Delvers%20Cover.png]]
 imageAlt: "Image for The Delver's Guide to Surviving the Underworld"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 ---
 _The Delver's Guide to Surviving the Underworld_ is a FREE expansion to _The Vagrant's Guide,_ brought to you by Jared Sorensen of [Memento Mori Theatricks.](http://www.memento-mori.com/) If you backed the Kickstarter or bought a PDF of Vagrants, it should already be available in your DriveThruRPG downloads alongside the parent tome.

--- a/src/content/projects/the-grind-3-hell-or-highwater.md
+++ b/src/content/projects/the-grind-3-hell-or-highwater.md
@@ -10,7 +10,7 @@ image: "[[https://f.hubspotusercontent10.net/hubfs/2068068/grind.jpg]]"
 imageAlt: "Image for The Grind Turn 3: Hell or Highwater"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 ---
 Chaos reigns!

--- a/src/content/projects/the-grind-turn-2.md
+++ b/src/content/projects/the-grind-turn-2.md
@@ -10,7 +10,7 @@ image: "[[https://cdn2.hubspot.net/hubfs/2068068/grind-2-mistvale-nights.jpg]]"
 imageAlt: "Image for The Grind Turn 2: Mistvale Nights"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 ---
 Chaos has spread to the valley of Mistvale...

--- a/src/content/projects/the-grind.md
+++ b/src/content/projects/the-grind.md
@@ -10,7 +10,7 @@ image: "[[https://cdn2.hubspot.net/hubfs/2068068/The%20Grind%20Front%20Cover.jpg
 imageAlt: "The Grind Front Cover"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: false
 ---
 Torchbearer RPG Zine

--- a/src/content/projects/the-vagrants-guide-to-surviving-the-wild-release.md
+++ b/src/content/projects/the-vagrants-guide-to-surviving-the-wild-release.md
@@ -10,7 +10,7 @@ image: "[[attachments/vagrants-attack-card.png]]"
 imageAlt: "Attack card in The Vagrant’s Guide to Surviving the Wild"
 hideCoverImage: false
 hideTOC: true
-draft: false
+environment: Production
 featured: true
 aliases:
   - the-vagrants-guide-to-surviving-the-wild

--- a/src/layouts/DocumentationLayout.astro
+++ b/src/layouts/DocumentationLayout.astro
@@ -12,6 +12,7 @@ import Lightbox from '@/components/Lightbox.astro';
 import ImageWrapper from '@/components/ImageWrapper.astro';
 import DocsSidebar from '@/components/DocsSidebar.astro';
 import Icon from '@/components/Icon.astro';
+import EnvironmentBanner from '@/components/EnvironmentBanner.astro';
 import { shouldShowContent, getAdjacentDocs, formatDate } from '@/utils/markdown';
 
 export interface Props {
@@ -230,6 +231,7 @@ const structuredData = {
 
           <!-- Documentation content -->
           <div class="prose dark:prose-dark max-w-none" id="documentation-content">
+            <EnvironmentBanner environment={documentation.data.environment} />
             <Content />
           </div>
         </div>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -9,6 +9,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 import TableOfContents from '@/components/TableOfContents.astro';
 import Lightbox from '@/components/Lightbox.astro';
 import ImageWrapper from '@/components/ImageWrapper.astro';
+import EnvironmentBanner from '@/components/EnvironmentBanner.astro';
 
 export interface Props {
   page: Page;
@@ -156,6 +157,7 @@ const structuredData = {
 
           <!-- Page content -->
           <div class="prose dark:prose-dark max-w-none" id="page-content">
+            <EnvironmentBanner environment={page.data.environment} />
             <Content />
           </div>
         </div>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -14,6 +14,7 @@ import GiscusComments from '@/components/GiscusComments.astro';
 import Lightbox from '@/components/Lightbox.astro';
 import Icon from '@/components/Icon.astro';
 import ImageWrapper from '@/components/ImageWrapper.astro';
+import EnvironmentBanner from '@/components/EnvironmentBanner.astro';
 import { devConfig } from '@/config/dev';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -258,6 +259,7 @@ if (siteConfig.postOptions.graphView.enabled && siteConfig.postOptions.graphView
 
         <!-- Article content -->
         <div class="prose dark:prose-dark max-w-none" id="post-content">
+          <EnvironmentBanner environment={post.data.environment} />
           <Content />
         </div>
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -19,6 +19,7 @@ import { Image } from 'astro:assets';
 import { devConfig } from '@/config/dev';
 import { getOptimizedFormat } from '@/utils/images';
 import ImageWrapper from '@/components/ImageWrapper.astro';
+import EnvironmentBanner from '@/components/EnvironmentBanner.astro';
 
 export interface Props {
   project: CollectionEntry<'projects'>;
@@ -283,6 +284,7 @@ const { prev: prevProject, next: nextProject } = getAdjacentPosts(visibleProject
 
           <!-- Article content -->
           <div class="prose dark:prose-dark max-w-none" id="project-content">
+            <EnvironmentBanner environment={project.data.environment} />
             <Content />
           </div>
 

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -10,7 +10,7 @@ function normalizeSiteUrl(url: string): string {
 export const GET: APIRoute = async () => {
   const siteUrl = normalizeSiteUrl(import.meta.env.SITE || siteConfig.site);
   const posts = await getCollection("posts", ({ data }) => {
-    return !data.draft;
+    return data.environment === 'Production';
   });
 
   // Sort posts by date (newest first)

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -236,58 +236,57 @@ function isDevelopmentMode(): boolean {
 
 // Check if a post should be shown in production
 export function shouldShowPost(post: Post, isDev: boolean | undefined = undefined): boolean {
-  const { draft, title, date } = post.data;
+  const { environment, title, date } = post.data;
 
   // Always require title and date
   if (!title || !date) {
     return false;
   }
 
-  // Determine if we're in dev mode (use provided value or check environment)
-  const inDevMode = isDev !== undefined ? isDev : isDevelopmentMode();
-
-  if (inDevMode && draft) {
-    // Hide drafts in dev mode
-   return false;
-  }
-
-  // In development mode only, show all posts (even drafts)
-  // In preview and production builds, hide drafts
-  if (inDevMode) {
-    return true;
-  }
-
-  // In production/preview, hide drafts (draft: true or undefined draft defaults to false)
-  if (draft === true) {
+  // Obsidian environment posts never show on the site (vault-only)
+  if (environment === 'Obsidian') {
     return false;
   }
 
-  return true;
+  // Determine if we're in dev mode (use provided value or check environment)
+  const inDevMode = isDev !== undefined ? isDev : isDevelopmentMode();
+
+  // In development mode, show Local and Production posts
+  if (inDevMode) {
+    return environment === 'Local' || environment === 'Production';
+  }
+
+  // In production/preview, only show Production environment posts
+  return environment === 'Production';
 }
 
 // Generic function to check if any content item should be shown
 export function shouldShowContent(
-  item: { data: { title: string; draft?: boolean } },
+  item: { data: { title: string; environment?: string } },
   isDev: boolean | undefined = undefined
 ): boolean {
-  const { draft, title } = item.data;
+  const { environment, title } = item.data;
 
   // Always require title
   if (!title) {
     return false;
   }
 
+  // Obsidian environment content never shows on the site (vault-only)
+  if (environment === 'Obsidian') {
+    return false;
+  }
+
   // Determine if we're in dev mode (use provided value or check environment)
   const inDevMode = isDev !== undefined ? isDev : isDevelopmentMode();
 
-  // In development mode only, show all content (even drafts)
-  // In preview and production builds, hide drafts
+  // In development mode, show Local and Production content
   if (inDevMode) {
-    return true;
+    return environment === 'Local' || environment === 'Production';
   }
 
-  // In production/preview, hide drafts
-  return !draft;
+  // In production/preview, only show Production environment content
+  return environment === 'Production';
 }
 
 // Sort content by date (newest first)


### PR DESCRIPTION

### Overview

This PR migrates the content visibility system from a boolean `draft` field to a three-state `environment` enum (`'Obsidian' | 'Local' | 'Production'`) across all content types (posts, projects, docs, pages). This enables more granular control over which content appears in development, local preview, and production environments.

### Key Changes

- **Schema Update:**  
  - Replaced `draft: boolean` with `environment: 'Obsidian' | 'Local' | 'Production'` in all content collection schemas (content.config.ts).
  - Default is now `environment: 'Production'`.

- **Content Filtering Logic:**  
  - Updated all filtering utilities (`shouldShowPost`, `shouldShowContent` in markdown.ts) to:
    - Never show `Obsidian` content on the site.
    - Show `Local` and `Production` content in dev mode (`pnpm run dev`).
    - Show only `Production` content in preview/production (`pnpm run preview` or deploy).
  - Updated feed and graph generation scripts to respect the new environment logic.

- **Bulk Content Migration:**  
  - Converted all markdown files to use the new `environment` field.
    - `draft: true` → `environment: Obsidian`
    - `draft: false` → `environment: Production`

- **UI/UX:**  
  - Added an `EnvironmentBanner` component that displays a warning in dev mode for `Local` content, using idiomatic Tailwind classes.

- **Testing & Verification:**  
  - Verified that only `Production` content appears in production/preview.
  - Confirmed that `Local` content is visible only in dev mode.
  - Ensured `Obsidian` content never appears on the site.

### How to Test

- Run `pnpm run dev` to see both `Local` and `Production` content.
- Run `pnpm run preview` to simulate production—only `Production` content will show.
- Deploy to GitHub Pages or other platforms—only `Production` content will be published.

### Why

- Enables a more flexible publishing workflow for Obsidian users.
- Prevents accidental publication of in-progress or vault-only content.
- Improves clarity and control for content creators.

---

Let me know if you want this in a specific format or with additional details!